### PR TITLE
Fix OpenAI embeddings function to handle chunked texts

### DIFF
--- a/backend/open_webui/apps/rag/utils.py
+++ b/backend/open_webui/apps/rag/utils.py
@@ -453,6 +453,14 @@ def generate_openai_embeddings(
 def generate_openai_batch_embeddings(
     model: str, texts: list[str], key: str, url: str = "https://api.openai.com/v1"
 ) -> Optional[list[list[float]]]:
+    def chunk_text(text, chunk_size):
+        return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+    if isinstance(texts, str):
+        texts = chunk_text(texts, 512)
+    else:
+        texts = [chunk for text in texts for chunk in chunk_text(text, 512)]
+
     try:
         r = requests.post(
             f"{url}/embeddings",


### PR DESCRIPTION
Update `generate_openai_batch_embeddings` function to handle chunking of texts.

* Add a helper function `chunk_text` to split text into chunks of 512 characters.
* Modify the `generate_openai_batch_embeddings` function to check if `texts` is a string and split it into chunks if necessary.
* Update the function to handle both single string and list of strings as input by chunking each text in the list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bgeneto/open-webui?shareId=e3fc2216-18f7-4a37-9ec0-1eb182b325aa).