### PR TITLE
Add preset buttons to chat controls

### DIFF
--- a/backend/open_webui/apps/webui/internal/migrations/019_add_preset_table.py
+++ b/backend/open_webui/apps/webui/internal/migrations/019_add_preset_table.py
@@ -1,0 +1,35 @@
+"""Peewee migrations -- 019_add_preset_table.py."""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your migrations here."""
+
+    @migrator.create_model
+    class Preset(pw.Model):
+        id = pw.AutoField()
+        user_id = pw.CharField(max_length=255)
+        name = pw.CharField(max_length=255)
+        system_prompt = pw.TextField()
+        advanced_params = pw_pext.JSONField()
+        created_at = pw.BigIntegerField()
+
+        class Meta:
+            table_name = "preset"
+            indexes = (
+                (("user_id", "name"), True),
+            )
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Write your rollback migrations here."""
+
+    migrator.remove_model("preset")

--- a/backend/open_webui/apps/webui/main.py
+++ b/backend/open_webui/apps/webui/main.py
@@ -19,6 +19,7 @@ from open_webui.apps.webui.routers import (
     tools,
     users,
     utils,
+    presets,  # Added import for presets router
 )
 from open_webui.apps.webui.utils import load_function_module_by_id
 from open_webui.config import (
@@ -121,6 +122,8 @@ app.include_router(functions.router, prefix="/functions", tags=["functions"])
 
 app.include_router(memories.router, prefix="/memories", tags=["memories"])
 app.include_router(utils.router, prefix="/utils", tags=["utils"])
+
+app.include_router(presets.router, prefix="/presets", tags=["presets"])  # Added presets router
 
 
 @app.get("/")

--- a/backend/open_webui/apps/webui/models/presets.py
+++ b/backend/open_webui/apps/webui/models/presets.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String, Text
+from open_webui.apps.webui.internal.db import Base, JSONField
+
+class Preset(Base):
+    __tablename__ = "preset"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False, unique=True)
+    system_prompt = Column(Text, nullable=False)
+    advanced_params = Column(JSONField, nullable=False)

--- a/backend/open_webui/apps/webui/routers/presets.py
+++ b/backend/open_webui/apps/webui/routers/presets.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from open_webui.apps.webui.internal.db import get_db
+from open_webui.apps.webui.models.presets import Preset
+from open_webui.apps.webui.models.users import get_current_user
+
+router = APIRouter()
+
+@router.post("/save", response_model=Preset)
+def save_preset(preset: Preset, db: Session = Depends(get_db), user=Depends(get_current_user)):
+    db_preset = db.query(Preset).filter(Preset.name == preset.name, Preset.user_id == user.id).first()
+    if db_preset:
+        raise HTTPException(status_code=400, detail="Preset name already exists")
+    preset.user_id = user.id
+    db.add(preset)
+    db.commit()
+    db.refresh(preset)
+    return preset
+
+@router.get("/", response_model=List[Preset])
+def get_presets(db: Session = Depends(get_db), user=Depends(get_current_user)):
+    return db.query(Preset).filter(Preset.user_id == user.id).all()
+
+@router.get("/{preset_name}", response_model=Preset)
+def get_preset(preset_name: str, db: Session = Depends(get_db), user=Depends(get_current_user)):
+    preset = db.query(Preset).filter(Preset.name == preset_name, Preset.user_id == user.id).first()
+    if not preset:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    return preset
+
+@router.delete("/{preset_name}", response_model=bool)
+def delete_preset(preset_name: str, db: Session = Depends(get_db), user=Depends(get_current_user)):
+    preset = db.query(Preset).filter(Preset.name == preset_name, Preset.user_id == user.id).first()
+    if not preset:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    db.delete(preset)
+    db.commit()
+    return True

--- a/src/lib/apis/presets/index.ts
+++ b/src/lib/apis/presets/index.ts
@@ -1,0 +1,16 @@
+import { api } from '$lib/utils/api';
+
+export const savePreset = async (preset) => {
+  const response = await api.post('/presets/save', preset);
+  return response.data;
+};
+
+export const loadPresets = async () => {
+  const response = await api.get('/presets');
+  return response.data;
+};
+
+export const deletePreset = async (presetName) => {
+  const response = await api.delete(`/presets/${presetName}`);
+  return response.data;
+};

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -8,11 +8,82 @@
 	import Valves from '$lib/components/chat/Controls/Valves.svelte';
 	import FileItem from '$lib/components/common/FileItem.svelte';
 	import Collapsible from '$lib/components/common/Collapsible.svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
 
 	import { user } from '$lib/stores';
 	export let models = [];
 	export let chatFiles = [];
 	export let params = {};
+
+	let showModal = false;
+	let presets = [];
+	let searchQuery = '';
+	let validationMessage = '';
+
+	// Function to save preset
+	const savePreset = async () => {
+		const presetName = prompt($i18n.t('Enter preset name:'));
+		if (!presetName) {
+			validationMessage = $i18n.t('Preset name cannot be empty.');
+			return;
+		}
+
+		const preset = {
+			name: presetName,
+			system_prompt: params.system,
+			advanced_params: params
+		};
+
+		try {
+			const response = await fetch('/api/presets/save', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(preset)
+			});
+
+			if (!response.ok) {
+				const errorData = await response.json();
+				validationMessage = $i18n.t(errorData.detail);
+				throw new Error('Failed to save preset');
+			}
+
+			alert($i18n.t('Preset saved successfully!'));
+			validationMessage = '';
+		} catch (error) {
+			console.error(error);
+			alert($i18n.t('Failed to save preset.'));
+		}
+	};
+
+	// Function to load preset
+	const loadPreset = async () => {
+		try {
+			const response = await fetch('/api/presets');
+			if (!response.ok) {
+				throw new Error('Failed to fetch presets');
+			}
+
+			presets = await response.json();
+			showModal = true;
+		} catch (error) {
+			console.error(error);
+			alert($i18n.t('Failed to load presets.'));
+		}
+	};
+
+	const applyPreset = (preset) => {
+		params.system = preset.system_prompt;
+		params = { ...params, ...preset.advanced_params };
+		showModal = false;
+	};
+
+	const filteredPresets = () => {
+		return presets.filter((preset) =>
+			preset.name.toLowerCase().includes(searchQuery.toLowerCase())
+		);
+	};
 </script>
 
 <div class=" dark:text-white">
@@ -87,5 +158,51 @@
 				</div>
 			</div>
 		</Collapsible>
+
+		<hr class="my-2 border-gray-100 dark:border-gray-800" />
+
+		<div class="flex justify-between mt-4">
+			<button
+				class="bg-blue-500 text-white px-4 py-2 rounded"
+				on:click={savePreset}
+			>
+				{$i18n.t('Save Preset')}
+			</button>
+			<button
+				class="bg-green-500 text-white px-4 py-2 rounded"
+				on:click={loadPreset}
+			>
+				{$i18n.t('Load Preset')}
+			</button>
+		</div>
+
+		{#if validationMessage}
+			<div class="text-red-500 mt-2">{validationMessage}</div>
+		{/if}
 	</div>
 </div>
+
+{#if showModal}
+	<Modal on:close={() => (showModal = false)}>
+		<div class="p-4">
+			<input
+				type="text"
+				placeholder={$i18n.t('Search presets')}
+				class="w-full mb-4 p-2 border rounded"
+				bind:value={searchQuery}
+			/>
+			<ul>
+				{#each filteredPresets() as preset}
+					<li class="mb-2">
+						<button
+							class="w-full text-left p-2 border rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+							on:click={() => applyPreset(preset)}
+						>
+							{preset.name}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	</Modal>
+{/if}

--- a/src/lib/components/chat/Controls/LoadPresetModal.svelte
+++ b/src/lib/components/chat/Controls/LoadPresetModal.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from '$lib/components/common/Modal.svelte';
+
+  export let showModal = false;
+  export let presets = [];
+  export let searchQuery = '';
+  export let applyPreset;
+  export let deletePreset;
+
+  const dispatch = createEventDispatcher();
+
+  const filteredPresets = () => {
+    return presets.filter((preset) =>
+      preset.name.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  };
+
+  const closeModal = () => {
+    showModal = false;
+    dispatch('close');
+  };
+
+  const handleDelete = (preset) => {
+    if (confirm(`Are you sure you want to delete the preset "${preset.name}"?`)) {
+      deletePreset(preset);
+    }
+  };
+</script>
+
+<Modal bind:show={showModal} on:close={closeModal}>
+  <div class="p-4">
+    <input
+      type="text"
+      placeholder="Search presets"
+      class="w-full mb-4 p-2 border rounded"
+      bind:value={searchQuery}
+    />
+    <ul>
+      {#each filteredPresets() as preset}
+        <li class="mb-2 flex justify-between items-center">
+          <button
+            class="w-full text-left p-2 border rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            on:click={() => applyPreset(preset)}
+          >
+            {preset.name}
+          </button>
+          <button
+            class="ml-2 text-red-500 hover:text-red-700"
+            on:click={() => handleDelete(preset)}
+          >
+            Delete
+          </button>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</Modal>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -52,6 +52,8 @@ export const temporaryChatEnabled = writable(false);
 export const scrollPaginationEnabled = writable(false);
 export const currentChatPage = writable(1);
 
+export const showLoadPresetModal = writable(false);
+
 export type Model = OpenAIModel | OllamaModel;
 
 type BaseModel = {


### PR DESCRIPTION
Add 'Save Preset' and 'Load Preset' buttons to the 'Chat Controls' right pane to save and load 'System Prompt' and 'Advanced Params' values to and from the database.

* **Frontend Changes:**
  - Add 'Save Preset' and 'Load Preset' buttons to `src/lib/components/chat/Controls/Controls.svelte`.
  - Add event handlers for 'Save Preset' and 'Load Preset' buttons.
  - Add a reserved area below the buttons for validation messages.
  - Create a modal window for selecting a preset in `src/lib/components/chat/Controls/LoadPresetModal.svelte`.
  - Add a search bar to filter presets by name and 'Delete' button next to each preset in the modal.
  - Add a store to manage the state of the 'Load Preset' modal in `src/lib/stores/index.ts`.

* **Backend Changes:**
  - Create a new migration file `backend/open_webui/apps/webui/internal/migrations/019_add_preset_table.py` to add the 'preset' table with specified columns and a composite index on the 'user_id' and 'name' columns.
  - Implement endpoints in `backend/open_webui/apps/webui/routers/presets.py` to save, load, and delete presets.
  - Add functions to call the save, load, and delete preset endpoints in `src/lib/apis/presets/index.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bgeneto/open-webui?shareId=ca59980e-0b3e-4857-9110-2e319a732920).